### PR TITLE
Use the 'nocookie' version of YouTube embeds

### DIFF
--- a/app/YtManagerApp/templates/YtManagerApp/video.html
+++ b/app/YtManagerApp/templates/YtManagerApp/video.html
@@ -18,7 +18,7 @@
                     </video>
                 {% else %}
                     <iframe id="ytplayer" type="text/html" width="100%" height="400"
-                          src="https://www.youtube.com/embed/{{ object.video_id }}?autoplay=1"
+                          src="https://www.youtube-nocookie.com/embed/{{ object.video_id }}?autoplay=1"
                           frameborder="0"></iframe>
                 {% endif %}
 


### PR DESCRIPTION
youtube-nocookie is an official hosted version of YouTube, but without the cookies. This ensures some additional privacy when watching content.