### PR TITLE
Remove references to `defaults.ini`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ individual user.
 4. Obtain an YouTube API developer key from [https://console.developers.google.com/apis/dashboard](https://console.developers.google.com/apis/dashboard).
 You can find a detailed guide on [this page](https://www.slickremix.com/docs/get-api-key-for-youtube/).
 
-    The `defaults.ini` file already has an API key, but if the quotas are reached, you won't be able to use this program 
+    The program already has a default API key, but if the quotas are reached, you won't be able to use this program 
     any more. Also, I might decide to delete that key, which will break your installation.
     
-    After obtaining the key, set it in `config.ini`.
+    You will be prompted for this key during the initial setup.
 
 5. Set up the database:
 
@@ -109,10 +109,10 @@ individual user.
 4. Obtain an YouTube API developer key from [https://console.developers.google.com/apis/dashboard](https://console.developers.google.com/apis/dashboard).
 You can find a detailed guide on [this page](https://www.slickremix.com/docs/get-api-key-for-youtube/).
 
-    The `defaults.ini` file already has an API key, but if the quotas are reached, you won't be able to use this program 
+    The program already has a default API key, but if the quotas are reached, you won't be able to use this program 
     any more. Also, I might decide to delete that key, which will break your installation.
     
-    After obtaining the key, set it in `config.ini`.
+    You will be prompted for this key during the initial setup.
 
 5. Build and run docker compose image:
 

--- a/config/config.ini
+++ b/config/config.ini
@@ -1,5 +1,4 @@
 ; Use ${env:environment_variable} to use the value of an environment variable.
-; If a variable is not set here, it will be loaded from defaults.ini.
 
 ; The global section contains settings that apply to the entire server
 [global]


### PR DESCRIPTION
The file `defaults.ini` no longer exists. As such, the documentation should no longer refer to it.